### PR TITLE
chore: update PR workflow to use M-Trust API Guard, widget tests, add Dependabot configuration

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,7 +39,7 @@ jobs:
         run: flutter analyze
       - name: Configure git
         run: |
-          git fetch --prune --unshallow
+          git fetch --prune
           git config --global user.name "GitHub Actions"
           git config --global user.email "gh-actions@emdgroup.com"
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,6 +1,7 @@
 name: "PR to Main"
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
     branches:
       - main
 
@@ -14,6 +15,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for all branches and tags
+
       - name: Install Flutter
         uses: subosito/flutter-action@v2
       - name: Install dependencies
@@ -42,6 +46,7 @@ jobs:
       - name: 🔂 Run standard-version
         run: |
           npx standard-version --skip.tag --skip.commit
+
       - name: ⏎ Get new version
         uses: actions/github-script@v7
         id: get_new_version
@@ -51,7 +56,15 @@ jobs:
             const fs = require('fs');
             const package = JSON.parse(fs.readFileSync('package.json', 'utf8'));
             return package.version;
-      - name: 💬 Comment on PR with new version
-        uses: thollander/actions-comment-pull-request@v2
+
+      - name: Run M-Trust API Guard
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        uses: emdgroup/mtrust-api-guard@main  # Or pin to a commit/tag
         with:
-          message: "New version ${{ steps.get_new_version.outputs.result }} 🚀 "
+          src_path: './lib/src'
+          base_doc: 'origin/main:./lib/documentation.g.dart'
+          new_doc: './lib/documentation.g.dart'
+          new_version: '${{ steps.get_new_version.outputs.result }}'
+          comment_on_pr: true
+          fail_on_error: true
+          ref: ${{ github.ref }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,9 +1,9 @@
-name: "PR to Main"
+name: "PR to Master"
 on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
-      - main
+      - master
 
 jobs:
   validate_pr:
@@ -62,7 +62,7 @@ jobs:
         uses: emdgroup/mtrust-api-guard@main  # Or pin to a commit/tag
         with:
           src_path: './lib/src'
-          base_doc: 'origin/main:./lib/documentation.g.dart'
+          base_doc: 'origin/master:./lib/documentation.g.dart'
           new_doc: './lib/documentation.g.dart'
           new_version: '${{ steps.get_new_version.outputs.result }}'
           comment_on_pr: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,10 +22,10 @@ jobs:
         uses: subosito/flutter-action@v2
       - name: Install dependencies
         run: flutter pub get
-      - name: Run build runner
-        run: flutter pub run build_runner build --delete-conflicting-outputs
-      - name: Generate l10n
-        run: flutter gen-l10n
+      # - name: Run build runner
+      #   run: flutter pub run build_runner build --delete-conflicting-outputs
+      # - name: Generate l10n
+      #   run: flutter gen-l10n
       - name: Run tests
         run: flutter test
       - name: Upload test failures

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,8 @@
-name: "Release Main"
+name: "Release Master"
 on:
   push:
     branches:
-      - main
+      - master
 jobs:
   release_liquid_flutter:
     runs-on: ubuntu-latest
@@ -67,7 +67,7 @@ jobs:
         run: flutter pub publish --dry-run
 
       - run: |
-          git push origin main
+          git push origin master
 
       - name: 🪵 Extract changelog for current version
         uses: actions/github-script@v7

--- a/lib/dependabot.yml
+++ b/lib/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "liquid-flutter-reactive-forms",
+  "version": "0.0.1",
+  "description": "A companion package to liquid_flutter that provides extensions for reactive_forms",
+  "scripts": {
+    "test": "flutter test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "yaml": "^2.7.1"
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: liquid_flutter_reactive_forms
 description: "A companion package to liquid_flutter that provides extensions for reactive_forms"
 version: 0.0.1
-homepage: https://github.com/emdgroup-liquid/liquid-flutter
+homepage: https://github.com/emdgroup-liquid/liquid-flutter-reactive-forms
 
 environment:
   sdk: ^3.6.1

--- a/test/liquid_flutter_reactive_forms_test.dart
+++ b/test/liquid_flutter_reactive_forms_test.dart
@@ -1,1 +1,312 @@
-void main() {}
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liquid_flutter/liquid_flutter.dart';
+import 'package:liquid_flutter_reactive_forms/liquid_flutter_reactive_forms.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+
+_wrapWithMaterialApp(Widget widget) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      LiquidLocalizations.delegate,
+    ],
+    home: Scaffold(
+      body: LdThemeProvider(
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Container(child: widget),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('LdFormSubmitConfig', () {
+    test('creates a copy with action', () {
+      // Arrange
+      final config = LdFormSubmitConfig(
+        loadingText: 'Loading...',
+        submitText: 'Submit',
+        allowResubmit: true,
+        withHaptics: false,
+        autoTrigger: true,
+        timeout: const Duration(seconds: 5),
+        allowCancel: true,
+      );
+
+      // Act
+      String actionResult = '';
+      final configWithAction = config.copyWithAction<String>(() async {
+        actionResult = 'Action executed';
+        return 'Success';
+      });
+
+      // Assert
+      expect(configWithAction.loadingText, equals('Loading...'));
+      expect(configWithAction.submitText, equals('Submit'));
+      expect(configWithAction.allowResubmit, isTrue);
+      expect(configWithAction.withHaptics, isFalse);
+      expect(configWithAction.autoTrigger, isTrue);
+      expect(configWithAction.timeout, equals(const Duration(seconds: 5)));
+      expect(configWithAction.allowCancel, isTrue);
+
+      // Check the action works
+      configWithAction.action();
+      expect(actionResult, equals('Action executed'));
+    });
+  });
+
+  group('LdReactiveForm', () {
+    testWidgets('renders form items correctly', (WidgetTester tester) async {
+      // Arrange
+      final formItems = [
+        LdReactiveFormItem.input<String>(
+          key: 'name',
+          inputFieldHint: 'Enter your name',
+          label: 'Name',
+        ),
+        LdReactiveFormItem.checkbox(
+          key: 'terms',
+          label: 'Accept Terms',
+        ),
+      ];
+
+      // Act
+      await tester.pumpWidget(
+        _wrapWithMaterialApp(
+          LdReactiveForm(
+            items: formItems,
+            onSubmit: (form) async => 'Success',
+          ),
+        ),
+      );
+
+      // Assert
+      expect(find.text('Name'), findsOneWidget);
+      expect(find.text('Enter your name'), findsOneWidget);
+      expect(find.text('Accept Terms'), findsOneWidget);
+      expect(find.byType(LdInput), findsOneWidget);
+      expect(find.byType(LdCheckbox), findsOneWidget);
+      expect(find.byType(LdSubmit<void>), findsOneWidget);
+    });
+
+    testWidgets('form validation works', (WidgetTester tester) async {
+      // Arrange
+      final formItems = [
+        LdReactiveFormItem.input<String>(
+          key: 'email',
+          inputFieldHint: 'Enter your email',
+          label: 'Email',
+          validators: [Validators.required, Validators.email],
+          validationMessages: {
+            'required': (error) => 'Email is required',
+            'email': (error) => 'Invalid email format',
+          },
+        ),
+      ];
+
+      // Act
+      await tester.pumpWidget(
+        _wrapWithMaterialApp(
+          LdReactiveForm(
+            items: formItems,
+            onSubmit: (form) async => 'Success',
+          ),
+        ),
+      );
+
+      // Find and tap the submit button
+      final submitButton = find.byType(LdButton);
+      expect(submitButton, findsOneWidget);
+      await tester.tap(submitButton);
+      await tester.pumpAndSettle();
+
+      // Assert - validation error should appear
+      expect(find.text('Email is required'), findsOneWidget);
+
+      // Enter invalid email and submit
+      await tester.enterText(find.byType(LdInput), 'not-an-email');
+      await tester.tap(submitButton);
+      await tester.pumpAndSettle();
+
+      // Assert - email validation error should appear
+      expect(find.text('Invalid email format'), findsOneWidget);
+
+      // Enter valid email and submit
+      await tester.enterText(find.byType(LdInput), 'test@example.com');
+      await tester.tap(submitButton);
+      await tester.pumpAndSettle();
+
+      // Assert - no validation errors
+      expect(find.text('Invalid email format'), findsNothing);
+      expect(find.text('Email is required'), findsNothing);
+    });
+
+    testWidgets('onSubmit is called with valid form',
+        (WidgetTester tester) async {
+      // Arrange
+      bool onSubmitCalled = false;
+      final formItems = [
+        LdReactiveFormItem.input<String>(
+          key: 'name',
+          inputFieldHint: 'Enter your name',
+          initialValue: 'John Doe', // Pre-populate with valid value
+        ),
+      ];
+
+      // Act
+      await tester.pumpWidget(
+        _wrapWithMaterialApp(
+          LdReactiveForm(
+            items: formItems,
+            onSubmit: (form) async {
+              onSubmitCalled = true;
+              return 'Success';
+            },
+          ),
+        ),
+      );
+
+      // Find and tap the submit button
+      final submitButton = find.byType(LdButton);
+      await tester.tap(submitButton);
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(onSubmitCalled, isTrue);
+    });
+
+    testWidgets('form is disabled during submission',
+        (WidgetTester tester) async {
+      // Arrange
+      final formItems = [
+        LdReactiveFormItem.input<String>(
+          key: 'name',
+          inputFieldHint: 'Enter your name',
+          initialValue: 'John Doe',
+        ),
+      ];
+
+      // Act
+      await tester.pumpWidget(
+        _wrapWithMaterialApp(
+          LdReactiveForm(
+            items: formItems,
+            onSubmit: (form) async {
+              // Simulate network delay
+              await Future.delayed(const Duration(milliseconds: 500));
+              return 'Success';
+            },
+            submitConfig: LdFormSubmitConfig(
+              loadingText: 'Submitting...',
+            ),
+          ),
+        ),
+      );
+
+      // Find and tap the submit button
+      final submitButton = find.byType(LdButton);
+      await tester.tap(submitButton);
+      await tester.pump(); // Pump once to start the submission process
+
+      // Assert that loading text is shown
+      expect(find.text('Submitting...'), findsOneWidget);
+
+      // Complete the submission
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('custom submit button appears correctly',
+        (WidgetTester tester) async {
+      // Arrange
+      final formItems = [
+        LdReactiveFormItem.input<String>(
+          key: 'name',
+          inputFieldHint: 'Enter your name',
+        ),
+      ];
+
+      // Act
+      await tester.pumpWidget(
+        _wrapWithMaterialApp(
+          LdReactiveForm(
+            items: formItems,
+            onSubmit: (form) async => 'Success',
+            submitBuilder: (context, form, child) {
+              return LdButton(
+                onPressed: () async {},
+                disabled: form.disabled,
+                child: const Text('Custom Submit'),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Assert
+      expect(find.text('Custom Submit'), findsOneWidget);
+    });
+
+    testWidgets('form validators are applied', (WidgetTester tester) async {
+      // Arrange
+      final formItems = [
+        LdReactiveFormItem.input<String>(
+          key: 'username',
+          inputFieldHint: 'Username',
+          initialValue: 'user1',
+        ),
+        LdReactiveFormItem.input<String>(
+          key: 'password',
+          inputFieldHint: 'Password',
+          initialValue: 'pass',
+        ),
+      ];
+
+      // Create a form-level validator that checks if username and password match
+      final formValidator = Validators.mustMatch(
+        'username',
+        'password',
+      );
+
+      bool onSubmitCalled = false;
+
+      // Act
+      await tester.pumpWidget(
+        _wrapWithMaterialApp(
+          LdReactiveForm(
+            items: formItems,
+            validators: [formValidator],
+            validationMessages: {
+              'matchError': (error) => 'Username and password must not match',
+            },
+            onSubmit: (form) async {
+              onSubmitCalled = true;
+              return 'Success';
+            },
+          ),
+        ),
+      );
+
+      // Find and tap the submit button
+      final submitButton = find.byType(LdButton);
+      await tester.tap(submitButton);
+      await tester.pumpAndSettle();
+
+      // Assert - form-level validation error should appear
+      expect(find.text('Username and password must not match'), findsNothing);
+      // Assert - onSubmit should not be called, as the form is invalid
+      expect(onSubmitCalled, isFalse);
+
+      // Make username and password match
+      await tester.enterText(find.byType(LdInput).first, 'same');
+      await tester.enterText(find.byType(LdInput).last, 'same');
+
+      // Submit again
+      await tester.tap(submitButton);
+      await tester.pumpAndSettle();
+
+      // Assert - form submission has been called
+      expect(onSubmitCalled, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
- add M-Trust API Guard to PR workflow
- disable build_runner and l10n generation steps (not (yet) used in this project)
- add some widget tests
- add Dependabot configuration